### PR TITLE
Adding mention of the Scoop package

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -10,7 +10,7 @@
 ## Download
 
 * Directly from [GitHub releases](https://github.com/crazy-max/WindowsSpyBlocker/releases/latest)
-* As a [Chocolate package](https://chocolatey.org/packages/windowsspyblocker) that will allow you to benefit from automatic updates
+* As a [Chocolatey package](https://chocolatey.org/packages/windowsspyblocker) that will allow you to benefit from automatic updates
 * As a [Scoop](https://scoop.sh/) package (`windowsspyblocker`) that will allow you to benefit from automatic updates
 
 ## First launch

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -11,6 +11,7 @@
 
 * Directly from [GitHub releases](https://github.com/crazy-max/WindowsSpyBlocker/releases/latest)
 * As a [Chocolate package](https://chocolatey.org/packages/windowsspyblocker) that will allow you to benefit from automatic updates
+* As a [Scoop](https://scoop.sh/) package (`windowsspyblocker`) that will allow you to benefit from automatic updates
 
 ## First launch
 


### PR DESCRIPTION
There is not only a Chocolatey package but also [a package](https://github.com/lukesampson/scoop-extras/blob/master/bucket/windowsspyblocker.json) on [Scoop](https://scoop.sh/), another Windows package manager.

Thanks for maintaining this project!